### PR TITLE
fix: show email preview when subject detected

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -54,13 +54,11 @@ Cuando el usuario diga que redactes o envíes el correo, sigue estas reglas estr
       const subjectMatch = content.match(/\[ASUNTO\]:\s*(.+)/i);
       if (subjectMatch) {
         setEmailSubject(subjectMatch[1].trim());
+        setEmailReady(true);
       }
 
       const cleanBody = content.replace(/\[ASUNTO\]:\s*.+/i, '').trim();
       setGeneratedEmail(cleanBody);
-
-      const esCorreo = cleanBody.length > 100;
-      if (esCorreo) setEmailReady(true);
 
       setMessages(prev => [...prev, { role: 'assistant', content }]);
     } catch (err) {


### PR DESCRIPTION
## Summary
- show generated email preview based on subject detection rather than arbitrary length

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689a4b3ca82083218b277fe88bab5566